### PR TITLE
Add coin flip simulation example

### DIFF
--- a/examples/coin_flip.py
+++ b/examples/coin_flip.py
@@ -1,0 +1,23 @@
+import random
+from collections import Counter
+import matplotlib.pyplot as plt
+
+TRIALS = 1000
+FLIPS_PER_TRIAL = 100
+
+results = []
+for _ in range(TRIALS):
+    heads = sum(random.choice([0, 1]) for _ in range(FLIPS_PER_TRIAL))
+    results.append(heads)
+
+count = Counter(results)
+
+print("Distribution of heads in %d trials of %d coin flips:" % (TRIALS, FLIPS_PER_TRIAL))
+for heads_count in sorted(count):
+    print(f"{heads_count}: {count[heads_count]}")
+
+plt.hist(results, bins=range(0, FLIPS_PER_TRIAL + 2), align='left', rwidth=0.8)
+plt.xlabel('Number of Heads')
+plt.ylabel('Frequency')
+plt.title('Distribution of Heads in 100 Coin Flips')
+plt.show()


### PR DESCRIPTION
## Summary
- create `examples/` directory
- add a Python script to simulate 100 coin flips in repeated trials and display the distribution of heads

## Testing
- `python3 examples/coin_flip.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68470c5a45dc832d80ad8309b8645c94